### PR TITLE
[mount-android] Directly bind-mount /vendor and eligible partitions scraped from the vendor fstab on the LXC rootfs

### DIFF
--- a/usr/lib/lxc-android/mount-android
+++ b/usr/lib/lxc-android/mount-android
@@ -2,8 +2,4 @@
 mkdir -p /dev/cpuset
 mount none /dev/cpuset -t cpuset -o nodev,noexec,nosuid
 
-/usr/sbin/mount-android.sh
-
-if [ -d /android/metadata ]; then
-    mount -o bind /android/metadata /var/lib/lxc/android/rootfs/metadata
-fi
+BIND_MOUNT_PATH="/var/lib/lxc/android/rootfs" /usr/sbin/mount-android.sh

--- a/var/lib/lxc/android/config
+++ b/var/lib/lxc/android/config
@@ -23,6 +23,4 @@ lxc.mount.entry = proc proc proc nodev,noexec,nosuid 0 0
 lxc.mount.entry = sys sys sysfs nodev,noexec,nosuid 0 0
 #lxc.mount.entry = tmp tmp tmpfs nodev,noexec,nosuid 0 0
 lxc.mount.entry = /android/data data bind bind 0 0
-lxc.mount.entry = /vendor vendor bind rbind 0 0
 lxc.mount.entry = /mnt mnt bind rbind 0 0
-lxc.mount.entry = /android/efs efs bind bind 0 0


### PR DESCRIPTION
This allows to reduce the number of partitions specified in the LXC
configuration in order to hopefully better handle exotic/legacy devices.

Signed-off-by: Eugenio Paolantonio (g7) <me@medesimo.eu>