### PR TITLE
Added rules for ignoring misbehaving BT devices in libinput

### DIFF
--- a/etc/udev/rules.d/90-btdevice-cursorfix.rules
+++ b/etc/udev/rules.d/90-btdevice-cursorfix.rules
@@ -1,0 +1,5 @@
+# Rules to fix cursor from incorrectly showing up on a Bluetooth device connection
+
+# 3 Monkeys Thunder Pro
+ACTION=="add", KERNEL=="event[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="3 Monkeys Thunder Pro", ENV{LIBINPUT_IGNORE_DEVICE}="1"
+


### PR DESCRIPTION
Some Bluetooth devices can cause a cursor to show up on the screen while connected, even though this shouldn't happen.
Added a rules file where these devices can be ignored, thus eliminating the cursor issue.