### PR TITLE
udev: add rule for synaptics touchpad

### DIFF
--- a/etc/udev/rules.d/90-touchscreen.rules
+++ b/etc/udev/rules.d/90-touchscreen.rules
@@ -4,6 +4,9 @@ ACTION=="add", KERNEL=="input[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="sec_ts",
 # Synaptics Clearpad
 ACTION=="add", KERNEL=="input[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="clearpad", ENV{ID_INPUT}="1", ENV{ID_INPUT_TOUCHSCREEN}="1"
 
+# Synaptics Touchpad
+ACTION=="add", KERNEL=="input[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="synaptics", ENV{ID_INPUT}="1", ENV{ID_INPUT_TOUCHSCREEN}="1"
+
 # (FIXME) aw9523b keyboard
 ACTION=="add", KERNEL=="event[0-9]*", SUBSYSTEM=="input", ATTRS{name}=="aw9523b", ENV{ID_INPUT}="1", ENV{ID_INPUT_KEY}="1"
 


### PR DESCRIPTION
Added rule for synaptics touchpad in 90-touchscreen.rules.

This fixes touchscreen issues for OnePlus 3 in ramdisk.