### PR TITLE
Revert "[lxc-android] Add support for process accounting"

### DIFF
--- a/var/lib/lxc/android/config
+++ b/var/lib/lxc/android/config
@@ -28,4 +28,3 @@ lxc.mount.entry = /mnt mnt bind rbind 0 0
 lxc.mount.entry = /apex apex bind bind,optional 0 0
 lxc.mount.entry = /odm odm bind bind,optional 0 0
 lxc.mount.entry = /vendor_dlkm vendor_dlkm bind bind,optional 0 0
-lxc.mount.entry = none acct cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot 0 0


### PR DESCRIPTION
This reverts commit f52146f3ea8deefe2c1252c8af82efc5a8f0baa8.

The commit in question prevents Droidian from booting properly on any device which doesn't have cgroupv2 support in the kernel so this should probably be reverted and we should come up with a better solution