### PR TITLE
[lxc-android] Fix added support for process accounting.

### DIFF
--- a/var/lib/lxc/android/config
+++ b/var/lib/lxc/android/config
@@ -28,3 +28,4 @@ lxc.mount.entry = /mnt mnt bind rbind 0 0
 lxc.mount.entry = /apex apex bind bind,optional 0 0
 lxc.mount.entry = /odm odm bind bind,optional 0 0
 lxc.mount.entry = /vendor_dlkm vendor_dlkm bind bind,optional 0 0
+lxc.mount.entry = none acct cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot,optional 0 0


### PR DESCRIPTION
As explained in the `lxc.mount.entry` section in the [lxc documentation](https://linuxcontainers.org/lxc/manpages/man5/lxc.container.conf.5.html): "Moreover lxc supports mount propagation, such as rshared or rprivate, and adds three additional mount options. optional don't fail if mount does not work."

So if we just use the `optional` mount option, it doesn't fail on cgroupv1 systems:
`lxc.mount.entry = none acct cgroup2 rw,nosuid,nodev,noexec,relatime,nsdelegate,memory_recursiveprot,optional 0 0`

Tested this on my OnePlus 3T, which doesn't have cgroupv2