### PR TITLE
Also mount droid-system-overlay on /android/system

### DIFF
--- a/usr/sbin/mount-android.sh
+++ b/usr/sbin/mount-android.sh
@@ -127,8 +127,18 @@ if [ -d "/usr/lib/droid-system-overlay" ]; then
     echo "mounting android's system overlay"
     if [ $(uname -r | cut -d "." -f 1) -ge "4" ]; then
         mount -t overlay overlay -o lowerdir=/usr/lib/droid-system-overlay:/var/lib/lxc/android/rootfs/system /var/lib/lxc/android/rootfs/system
+        echo "overlayed on /var/lib/lxc/android/rootfs/system"
+        if [ -d "/android/system" ]; then
+            mount -t overlay overlay -o lowerdir=/usr/lib/droid-system-overlay:/android/system /android/system
+            echo "overlayed on /android/system"
+        fi
     else
         mount -t overlay overlay -o lowerdir=/var/lib/lxc/android/rootfs/system,upperdir=/usr/lib/droid-system-overlay,workdir=/var/lib/lxc/android/ /var/lib/lxc/android/rootfs/system
+        echo "overlayed on /var/lib/lxc/android/rootfs/system"
+        if [ -d "/android/system" ]; then
+            mount -t overlay overlay -o lowerdir=/android/system,upperdir=/usr/lib/droid-system-overlay,workdir=/android/ /android/system
+            echo "overlayed on /android/system"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Before, the droid-system-overlay directory was overlayed only on the /var/lib/lxc/android/rootfs/system path.

But the android system image is also mounted on /android as loop device, and the overlay was not applied on /android/system

This was detected because some system overlays was not taking effect on some audio recording tests.

This change overlays the droid-vsystem-overlay directory on the /android/system path too.